### PR TITLE
feat: handle redirect

### DIFF
--- a/Source/Commands/Download.swift
+++ b/Source/Commands/Download.swift
@@ -32,12 +32,13 @@ extension Download {
         
         logger.log("Creating HTTP client...", level: .debug)
         let httpClient = HTTPClient(urlSession: URLSession.shared)
+        let httpStoreClient = HTTPClient(urlSession: URLSession.noRedirect)
 
         logger.log("Creating iTunes client...", level: .debug)
         let itunesClient = iTunesClient(httpClient: httpClient)
 
         logger.log("Creating App Store client...", level: .debug)
-        let storeClient = StoreClient(httpClient: httpClient)
+        let storeClient = StoreClient(httpClient: httpStoreClient)
 
         logger.log("Creating download client...", level: .debug)
         let downloadClient = HTTPDownloadClient()
@@ -104,6 +105,8 @@ extension Download {
                     switch error {
                     case StoreClient.Error.invalidResponse:
                         logger.log("Received invalid response.", level: .error)
+                    case StoreClient.Error.tooManyAttempts:
+                        logger.log("Too many attempts.", level: .error)
                     case StoreResponse.Error.invalidAccount:
                         logger.log("This Apple ID has not been set up to use the App Store.", level: .error)
                     case StoreResponse.Error.invalidCredentials:
@@ -122,6 +125,8 @@ extension Download {
                 switch error {
                 case StoreClient.Error.invalidResponse:
                     logger.log("Received invalid response.", level: .error)
+                case StoreClient.Error.tooManyAttempts:
+                    logger.log("Too many attempts.", level: .error)
                 case StoreResponse.Error.invalidAccount:
                     logger.log("This Apple ID has not been set up to use the App Store.", level: .error)
                 case StoreResponse.Error.invalidCredentials:

--- a/Source/Networking/HTTPClient.swift
+++ b/Source/Networking/HTTPClient.swift
@@ -54,7 +54,7 @@ final class HTTPClient: HTTPClientInterface {
                     return completion(.failure(Error.invalidResponse(response)))
                 }
                 
-                completion(.success(.init(statusCode: response.statusCode, data: data)))
+                completion(.success(.init(statusCode: response.statusCode, headers: response.allHeaderFields, data: data)))
             }.resume()
         } catch {
             completion(.failure(error))

--- a/Source/Networking/HTTPResponse.swift
+++ b/Source/Networking/HTTPResponse.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct HTTPResponse {
     let statusCode: Int
+    let headers: [AnyHashable: Any]
     let data: Data?
 }
 

--- a/Source/Networking/RedirectEndpoint.swift
+++ b/Source/Networking/RedirectEndpoint.swift
@@ -1,0 +1,20 @@
+//
+//  RedirectEndpoint.swift
+//  ipatool
+//
+//  Created by Vladislav Iakovlev on 06.10.25.
+//
+
+import Foundation
+
+class RedirectEndpoint: HTTPEndpoint {
+    var url: URL
+
+    init?(location: Any?) {
+        guard let location = location as? String, let url = URL(string: location) else {
+            return nil
+        }
+
+        self.url = url
+    }
+}

--- a/Source/Networking/URLSession.swift
+++ b/Source/Networking/URLSession.swift
@@ -11,4 +11,20 @@ protocol URLSessionInterface {
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
 }
 
-extension URLSession: URLSessionInterface {}
+final class URLSessionNoRedirectDelegate: NSObject, URLSessionDataDelegate {
+    static var shared = URLSessionNoRedirectDelegate()
+
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        completionHandler(nil)
+    }
+}
+
+extension URLSession: URLSessionInterface {
+    static var noRedirect = URLSession(configuration: .default,
+                                       delegate: URLSessionNoRedirectDelegate.shared,
+                                       delegateQueue: nil)
+}

--- a/Source/Store/StoreEndpoint.swift
+++ b/Source/Store/StoreEndpoint.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum StoreEndpoint {
-    case authenticate(prefix: String, guid: String)
+    case authenticate
     case download(guid: String)
 }
 
@@ -22,8 +22,8 @@ extension StoreEndpoint: HTTPEndpoint {
     
     private var host: String {
         switch self {
-        case let .authenticate(prefix, _):
-            return "\(prefix)-buy.itunes.apple.com"
+        case .authenticate:
+            return "buy.itunes.apple.com"
         case .download:
             return "p25-buy.itunes.apple.com"
         }
@@ -31,8 +31,8 @@ extension StoreEndpoint: HTTPEndpoint {
     
     private var path: String {
         switch self {
-        case let .authenticate(_, guid):
-            return "/WebObjects/MZFinance.woa/wa/authenticate?guid=\(guid)"
+        case .authenticate:
+            return "/WebObjects/MZFinance.woa/wa/authenticate"
         case let .download(guid):
             return "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=\(guid)"
         }

--- a/Source/Store/StoreRequest.swift
+++ b/Source/Store/StoreRequest.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 enum StoreRequest {
-    case authenticate(email: String, password: String, code: String? = nil)
+    case authenticate(email: String, password: String, code: String? = nil, attempt: Int? = nil, redirect: HTTPEndpoint? = nil)
     case download(appIdentifier: String, directoryServicesIdentifier: String)
 }
 
 extension StoreRequest: HTTPRequest {
     var endpoint: HTTPEndpoint {
         switch self {
-        case let .authenticate(_, _, code):
-            return StoreEndpoint.authenticate(prefix: (code == nil) ? "p25" : "p71", guid: guid)
+        case let .authenticate(_, _, _, _, redirect):
+            return redirect ?? StoreEndpoint.authenticate
         case .download:
             return StoreEndpoint.download(guid: guid)
         }
@@ -45,11 +45,10 @@ extension StoreRequest: HTTPRequest {
     
     var payload: HTTPPayload? {
         switch self {
-        case let .authenticate(email, password, code):
+        case let .authenticate(email, password, code, attempt, _):
             return .xml([
                 "appleId": email,
-                "attempt": "\(code == nil ? "4" : "2")",
-                "createSession": "true",
+                "attempt": String(attempt ?? 1),
                 "guid": guid,
                 "password": "\(password)\(code ?? "")",
                 "rmp": "0",

--- a/Source/Store/StoreResponse.swift
+++ b/Source/Store/StoreResponse.swift
@@ -62,7 +62,7 @@ extension StoreResponse: Decodable {
             switch message {
             case "Your account information was entered incorrectly.":
                 self = .failure(error: Error.invalidCredentials)
-            case "An Apple ID verification code is required to sign in. Type your password followed by the verification code shown on your other devices.":
+            case "An Apple ID verification code is required to sign in. Type your password followed by the verification code shown on your other devices.", "MZFinance.BadLogin.Configurator_message":
                 self = .failure(error: Error.codeRequired)
             case "This Apple ID has been locked for security reasons. Visit iForgot to reset your account (https://iforgot.apple.com).":
                 self = .failure(error: Error.lockedAccount)

--- a/ipatool.xcodeproj/project.pbxproj
+++ b/ipatool.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		65EECE7A2673C8EA00014AF4 /* Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EECE782673C8EA00014AF4 /* Download.swift */; };
 		65EECE7B2673C8EA00014AF4 /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EECE792673C8EA00014AF4 /* Search.swift */; };
 		65EECE7E2673C97500014AF4 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 65EECE7D2673C97500014AF4 /* ZIPFoundation */; };
+		F5BBBA3C2E9366CA00A929EE /* RedirectEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BBBA3B2E9366C400A929EE /* RedirectEndpoint.swift */; };
 		FA8FFD3D24ABB7D0008FD73C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA8FFD3C24ABB7D0008FD73C /* Assets.xcassets */; };
 		FA8FFD4024ABB7D0008FD73C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FA8FFD3E24ABB7D0008FD73C /* LaunchScreen.storyboard */; };
 		FA8FFD4B24ABBDB0008FD73C /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = FA8FFD4A24ABBDB0008FD73C /* ArgumentParser */; };
@@ -61,6 +62,7 @@
 		65EECE722673C8BE00014AF4 /* StoreResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreResponse.swift; sourceTree = "<group>"; };
 		65EECE782673C8EA00014AF4 /* Download.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Download.swift; sourceTree = "<group>"; };
 		65EECE792673C8EA00014AF4 /* Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
+		F5BBBA3B2E9366C400A929EE /* RedirectEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectEndpoint.swift; sourceTree = "<group>"; };
 		FA8FFD3024ABB7CB008FD73C /* ipatool.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ipatool.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA8FFD3C24ABB7D0008FD73C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FA8FFD3F24ABB7D0008FD73C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 		65EECE5A2673C8A800014AF4 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				F5BBBA3B2E9366C400A929EE /* RedirectEndpoint.swift */,
 				65EECE5B2673C8A800014AF4 /* HTTPEndpoint.swift */,
 				65EECE5C2673C8A800014AF4 /* HTTPPayload.swift */,
 				65EECE5D2673C8A800014AF4 /* HTTPRequest.swift */,
@@ -296,6 +299,7 @@
 				65EECE682673C8A800014AF4 /* HTTPClient.swift in Sources */,
 				FA8FFD4D24ABBE14008FD73C /* main.swift in Sources */,
 				65EECE582673C89B00014AF4 /* LogLevel.swift in Sources */,
+				F5BBBA3C2E9366CA00A929EE /* RedirectEndpoint.swift in Sources */,
 				65EECE512673C88F00014AF4 /* iTunesClient.swift in Sources */,
 				65EECE502673C88F00014AF4 /* iTunesEndpoint.swift in Sources */,
 				65EECE4F2673C88F00014AF4 /* iTunesResponse.swift in Sources */,


### PR DESCRIPTION
## Proposed changes

- Update minimum version to iOS 12:
   I couldn't build with it targeted to iOS 9 on latest Xcode. It tells that `ArgumentParser` only available on iOS 12. Please let me know if it's possible to build with some workaround instead.
- Add redirect handling:
   In ipatool: https://github.com/majd/ipatool/blob/91ae69cc58c25c4a66bcbff6ca93b2e4d56c1d7a/pkg/appstore/appstore_login.go#L128-L133
   Authorization wasn't working for me, it sent 2FA code once, but then only "An unknown error has occurred." Authorization request just returned 404. I think these `pxx-`  (like `p25-` and `p71-`) may depend on the account region and it wasn't working for Spain. Now it first sends request without prefix and then follows redirects handled manually. Automatic redirects from `URLSession` and `curl` don't work for some reason, so I've added `URLSession.noRedirect` to ignore them and handle manually.
- Add new error message when 2FA code requested:
   In ipatool: https://github.com/majd/ipatool/blob/91ae69cc58c25c4a66bcbff6ca93b2e4d56c1d7a/pkg/appstore/constants.go#L9
   Now when ipatool-ios should ask for 2FA code instead of throwing the error (#2).