### PR TITLE
feat: add output argument to download command

### DIFF
--- a/Source/Commands/Download.swift
+++ b/Source/Commands/Download.swift
@@ -157,8 +157,7 @@ extension Download {
             output = "\(bundleIdentifier)_\(app.identifier)_v\(app.version)_\(Int.random(in: 100...999)).ipa"
         }
         
-        let outputUrl = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-            .appendingPathComponent(output)
+        let outputUrl = URL(fileURLWithPath: output, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)).absoluteURL
         logger.log("Output path: '\(outputUrl.path)'.", level: .debug)
 
         logger.log("Creating signature client...", level: .debug)

--- a/Source/Commands/Download.swift
+++ b/Source/Commands/Download.swift
@@ -22,6 +22,9 @@ struct Download: ParsableCommand {
     @Option(name: [.short, .long], help: "The password for the Apple ID.")
     private var password: String?
 
+    @Option(name: [.short, .long], help: "The destination path of the downloaded app package.")
+    private var output: String?
+
     @Option
     private var logLevel: LogLevel = .info
 }
@@ -145,22 +148,29 @@ extension Download {
         logger.log("Requesting a signed copy of '\(app.identifier)' from the App Store...", level: .info)
         let item = try storeClient.item(identifier: "\(app.identifier)", directoryServicesIdentifier: account.directoryServicesIdentifier)
         logger.log("Received a response of the signed copy: \(item.md5).", level: .debug)
-        
-        logger.log("Creating signature client...", level: .debug)
-        let path = FileManager.default.currentDirectoryPath
-            .appending("/\(bundleIdentifier)_\(app.identifier)_v\(app.version)_\(Int.random(in: 100...999))")
-            .appending(".ipa")
 
-        logger.log("Output path: \(path).", level: .debug)
-        let signatureClient = SignatureClient(fileManager: .default, filePath: path)
+        let output: String
+
+        if let cliOutput = self.output {
+            output = cliOutput
+        } else {
+            output = "\(bundleIdentifier)_\(app.identifier)_v\(app.version)_\(Int.random(in: 100...999)).ipa"
+        }
+        
+        let outputUrl = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(output)
+        logger.log("Output path: '\(outputUrl.path)'.", level: .debug)
+
+        logger.log("Creating signature client...", level: .debug)
+        let signatureClient = SignatureClient(fileManager: .default, fileUrl: outputUrl)
 
         logger.log("Downloading app package...", level: .info)
-        try downloadClient.download(from: item.url, to: URL(fileURLWithPath: path)) { progress in
+        try downloadClient.download(from: item.url, to: outputUrl) { progress in
             logger.log("Downloading app package... [\(Int((progress * 100).rounded()))%]",
                        prefix: "\u{1B}[1A\u{1B}[K",
                        level: .info)
         }
-        logger.log("Saved app package to \(URL(fileURLWithPath: path).lastPathComponent).", level: .info)
+        logger.log("Saved app package to '\(outputUrl.path)'.", level: .info)
 
         logger.log("Applying patches...", level: .info)
         try signatureClient.appendMetadata(item: item, email: email)

--- a/Source/Networking/HTTPDownloadClient.swift
+++ b/Source/Networking/HTTPDownloadClient.swift
@@ -74,6 +74,7 @@ extension HTTPDownloadClient: URLSessionDownloadDelegate {
         }
         
         do {
+            try? FileManager.default.removeItem(at: target)
             try FileManager.default.moveItem(at: location, to: target)
             completionHandler?(.success(()))
         } catch {

--- a/Source/Signature/SignatureClient.swift
+++ b/Source/Signature/SignatureClient.swift
@@ -15,15 +15,15 @@ protocol SignatureClientInterface {
 
 final class SignatureClient: SignatureClientInterface {
     private let fileManager: FileManager
-    private let filePath: String
+    private let fileUrl: URL
     
-    init(fileManager: FileManager, filePath: String) {
+    init(fileManager: FileManager, fileUrl: URL) {
         self.fileManager = fileManager
-        self.filePath = filePath
+        self.fileUrl = fileUrl
     }
     
     func appendMetadata(item: StoreResponse.Item, email: String) throws {
-        guard let archive = Archive(url: URL(fileURLWithPath: filePath), accessMode: .update) else  {
+        guard let archive = Archive(url: fileUrl, accessMode: .update) else  {
             throw Error.invalidArchive
         }
 
@@ -40,7 +40,7 @@ final class SignatureClient: SignatureClientInterface {
     }
     
     func appendSignature(item: StoreResponse.Item) throws {
-        guard let archive = Archive(url: URL(fileURLWithPath: filePath), accessMode: .update) else  {
+        guard let archive = Archive(url: fileUrl, accessMode: .update) else  {
             throw Error.invalidArchive
         }
 


### PR DESCRIPTION
## Proposed changes

- Add `-o`, `--output` argument to `download` command similar to https://github.com/majd/ipatool?tab=readme-ov-file#usage
- Use same output file URL for logs, downloading and adding signature
- Remove output file if it exists

Should I also change `<bundle>_<id>_v<version>_<random>.ipa` to `<bundle>_<id>_<version>.ipa` to match default `output` of ipatool?